### PR TITLE
[DOC] Fix cpojer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jest-pytest
 
-Based on @cpojer's amazing [Jest / Pytest work here](https://github.com/cpojer/pyjest), and adapted to work with pytest snapshots and a custom [JSON pytest reporter](https://github.com/jondot/pytest-jest).
+Based on [@cpojer](https://github.com/cpojer)'s amazing [Jest / Pytest work here](https://github.com/cpojer/pyjest), and adapted to work with pytest snapshots and a custom [JSON pytest reporter](https://github.com/jondot/pytest-jest).
 
 Essentially, it's:
 


### PR DESCRIPTION
I wanted to track the link to see his profile so it bothered me. A shame that Github doesn't do it by themselves (https://github.com/github/markup/issues/209)